### PR TITLE
Update spec for `Metatags.put`

### DIFF
--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -32,7 +32,7 @@ defmodule Metatags do
     put(conn, Atom.to_string(key), value)
   end
 
-  @spec put(Conn.t(), String.t(), String.t() | map) :: struct
+  @spec put(Conn.t(), String.t(), String.t() | map | nil) :: struct
   def put(%Conn{private: %{metatags: metatags}} = conn, key, value) do
     metatags =
       metatags


### PR DESCRIPTION
Allow setting a value to `nil`. This might be useful in cases where you'd like to reset another value or prevent a title from being printed