### PR TITLE
Move configuration to the `Plug` definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,25 @@ def deps do
 end
 ```
 
-Configure the defaults in confix.ex
+Add the plug to your router and configure the defaults
+(You can use `Application.get_env/3` if you'd like to extract it into the
+configuration file).
 
 ```elixir
-config :metatags,
-    sitename: "My_app",
-    separator: "-",
-    default_tags: %{
-        "title" => "Welcome!",
-        "description" => "My_app is a great app",
-        "keywords" => ["My_app", "great", "elixir"]
-    }
+defmodule MyRouter do
+  use Plug.Conn
+
+  plug Metatags,
+     sitename: "My_app",
+     separator: "-",
+     default_tags: %{
+       "title" => "Welcome!",
+       "description" => "My_app is a great app",
+       "keywords" => ["My_app", "great", "elixir"]
+     }
 ```
 
 ## Usage
-
-Add metatags as a plug. either directly in a scope or into a Phoenix pipeline
-```elixir
-plug Metatags
-```
 
 In your controller put page specific data
 ```elixir

--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -9,13 +9,21 @@ defmodule Metatags do
 
   @type metatag_value :: String.t() | [String.t()] | map() | nil
 
-  @doc false
-  def init(_opts), do: nil
+  @default_metatags %{"title" => nil}
 
   @doc false
-  def call(conn, _opts) do
+  def init(options) do
+    options
+    |> Keyword.get(:defaults, [])
+    |> Enum.reduce(@default_metatags, fn {key, value}, default_tags ->
+      Map.put(default_tags, to_string(key), value)
+    end)
+  end
+
+  @doc false
+  def call(conn, defaults) do
     conn
-    |> Conn.put_private(:metatags, default_metatags())
+    |> Conn.put_private(:metatags, defaults)
   end
 
   @doc """
@@ -50,12 +58,5 @@ defmodule Metatags do
   @spec print_tags(Conn.t()) :: Phoenix.HTML.Safe.t()
   def print_tags(%Conn{} = conn) do
     HTML.from_conn(conn)
-  end
-
-  defp default_metatags do
-    config = Application.get_env(:metatags, :default_tags, %{})
-
-    %{"title" => nil}
-    |> Map.merge(config)
   end
 end

--- a/test/metatags/html_test.exs
+++ b/test/metatags/html_test.exs
@@ -62,10 +62,12 @@ defmodule Metatags.HTMLTest do
     end
   end
 
-  defp build_conn do
+  defp build_conn(default_metatags \\ []) do
+    defaults = Metatags.init(default_metatags)
+
     :get
     |> conn("/")
-    |> Metatags.call([])
+    |> Metatags.call(defaults)
   end
 
   defp safe_to_string(safe_string) do

--- a/test/metatags_test.exs
+++ b/test/metatags_test.exs
@@ -3,16 +3,26 @@ defmodule MetatagsTest do
   use Plug.Test
 
   describe "init" do
-    test "returns nil" do
-      assert nil == Metatags.init([])
+    test "returns an empty keyword list" do
+      assert %{"title" => nil} == Metatags.init([])
+    end
+
+    test "returns the passed defaults as a map" do
+      assert %{"title" => "title"} == Metatags.init(defaults: [title: "title"])
     end
   end
 
   describe "call" do
-    test "sets the default metatags" do
-      conn = Metatags.call(conn(:get, "/"), [])
+    test "sets the passed defaults" do
+      conn = Metatags.call(conn(:get, "/"), %{"title" => nil})
 
       assert %{"title" => nil} == conn.private.metatags
+    end
+
+    test "uses the passed defaults when present" do
+      conn = Metatags.call(conn(:get, "/"), %{"title" => "title"})
+
+      assert %{"title" => "title"} == conn.private.metatags
     end
   end
 
@@ -39,10 +49,12 @@ defmodule MetatagsTest do
     end
   end
 
-  defp build_conn do
+  defp build_conn(default_metatags \\ []) do
+    defaults = Metatags.init(default_metatags)
+
     :get
     |> conn("/")
-    |> Metatags.call([])
+    |> Metatags.call(defaults)
   end
 
   defp safe_to_string(safe_string) do


### PR DESCRIPTION
Background:
To allow usage of metatags in multiple BEAM applications running on the
same VM (as is quite common in umbrella applications) we'd have to
rework how the default metatags is defined. Earlier the metatags would
be configured globally which meant the configuration would
clash/overwrite each other. This change will move the defining of
metatags to be where the plug is used instead.

Configuring defaults will still be available through
`Application.get_env/3`.

Changes:
- Update README
- Allow the plug to take the default metadata