### PR TITLE
Refactor module structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## 0.3.0
 - Move configuration of default values to the plug definition
+- Extract the plug to `Metatags.Plug`
 
-  To migrate, just move whatever you have in your configuration and put
-  behind `plug Metatags` in your router. If you require environment specific
-  defaults, use `Application.get_env/3`.
+  *Migrate*:
+  First, change the plug from `Metatags` to `Metatags.Plug`.
+  After that you can move whatever you have in your configuration and put
+  behind `plug Metatags.Plug` in your router. If you require environment
+  specific defaults, use `Application.get_env/3`.
 
 ## 0.2.2
 - Add `[String.t()]` to `Metatags.put/3` type spec

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ configuration file).
 defmodule MyRouter do
   use Plug.Conn
 
-  plug Metatags,
+  plug Metatags.Plug,
      sitename: "My_app",
      separator: "-",
      default_tags: %{

--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -1,6 +1,6 @@
 defmodule Metatags do
   @moduledoc """
-    Metatags is used to provide an easy api to print out context-specific
+    Metatags is used to provide an easy API to print out context-specific
     metatags.
   """
 
@@ -8,23 +8,6 @@ defmodule Metatags do
   alias Plug.Conn
 
   @type metatag_value :: String.t() | [String.t()] | map() | nil
-
-  @default_metatags %{"title" => nil}
-
-  @doc false
-  def init(options) do
-    options
-    |> Keyword.get(:defaults, [])
-    |> Enum.reduce(@default_metatags, fn {key, value}, default_tags ->
-      Map.put(default_tags, to_string(key), value)
-    end)
-  end
-
-  @doc false
-  def call(conn, defaults) do
-    conn
-    |> Conn.put_private(:metatags, defaults)
-  end
 
   @doc """
     Puts a key and a value in the on a %Conn{} struct
@@ -44,12 +27,12 @@ defmodule Metatags do
 
   @spec put(Conn.t(), String.t(), metatag_value()) :: struct
   def put(%Conn{private: %{metatags: metatags}} = conn, key, value) do
-    metatags =
-      metatags
-      |> Map.put(key, value)
+    {_, metatags} =
+      Map.get_and_update(metatags, :metatags, fn metadata ->
+        {metadata, Map.put(metadata, key, value)}
+      end)
 
-    conn
-    |> Conn.put_private(:metatags, metatags)
+    Conn.put_private(conn, :metatags, metatags)
   end
 
   @doc """

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -1,0 +1,11 @@
+defmodule Metatags.Config do
+  @moduledoc false
+
+  defstruct sitename: nil, title_separator: "-", metatags: %{}
+
+  @type t :: %__MODULE__{
+          sitename: nil | String.t(),
+          title_separator: String.t(),
+          metatags: %{}
+        }
+end

--- a/lib/metatags/html.ex
+++ b/lib/metatags/html.ex
@@ -6,31 +6,16 @@ defmodule Metatags.HTML do
   alias Phoenix.HTML
   alias Phoenix.HTML.Tag
 
-  @type base_option ::
-          {:sitename, String.t()}
-          | {:separator, String.t()}
-          | {:default_tags, map()}
-  @type base_options :: [base_option()]
-
   @doc """
   Turns a %Plug.Conn{} with metatags into HTML
   """
-  @spec from_conn(Plug.Conn.t(), base_options()) :: HTML.Safe.t()
-  def from_conn(%Plug.Conn{private: %{metatags: metatags}}, base_options)
-      when is_list(base_options) do
+  @spec from_conn(Plug.Conn.t()) :: HTML.Safe.t()
+  def from_conn(%Plug.Conn{private: %{metatags: metatags}}) do
+    {metatags, config} = Map.pop(metatags, :metatags)
+
     Enum.reduce(metatags, [], fn {key, value}, acc ->
-      [print_tag(metatags, key, value, base_options) | acc]
+      [print_tag(metatags, key, value, config) | acc]
     end)
-  end
-
-  def from_conn(%Plug.Conn{private: %{metatags: _}} = conn) do
-    default_options = [
-      sitename: Application.get_env(:metatags, :sitename),
-      separator: Application.get_env(:metatags, :separator),
-      default_tags: Application.get_env(:metatags, :default_tags)
-    ]
-
-    from_conn(conn, default_options)
   end
 
   def from_conn(_) do
@@ -39,29 +24,31 @@ defmodule Metatags.HTML do
         "No metatags was present in the passed struct. Did you forget to add it?"
   end
 
-  defp print_tag(metatags, prefix, %{} = map, base_options) do
+  defp print_tag(metatags, prefix, %{} = map, config) do
     map
     |> Enum.reduce([], fn {key, value}, acc ->
-      [print_tag(metatags, "#{prefix}:#{key}", value, base_options) | acc]
+      [print_tag(metatags, "#{prefix}:#{key}", value, config) | acc]
     end)
   end
 
-  defp print_tag(_, "title", value, base_options) when is_nil(value) do
-    Tag.content_tag(:title, do: Keyword.get(base_options, :sitename))
+  defp print_tag(_, "title", nil, %{sitename: nil}), do: ""
+
+  defp print_tag(_, "title", value, %{sitename: sitename}) when is_nil(value) do
+    Tag.content_tag(:title, do: sitename)
   end
 
-  defp print_tag(_, "title", value, base_options) do
-    sitename = Keyword.get(base_options, :sitename)
-    separator = Keyword.get(base_options, :separator, "-")
-
+  defp print_tag(_, "title", value, %{
+         sitename: sitename,
+         title_separator: separator
+       }) do
     suffix = if sitename, do: [separator, sitename], else: []
 
     Tag.content_tag(:title, do: Enum.join([value] ++ suffix, " "))
   end
 
-  defp print_tag(metatags, "keywords" = key, value, base_options)
+  defp print_tag(metatags, "keywords", value, config)
        when is_list(value) do
-    print_tag(metatags, key, Enum.join(value, ", "), base_options)
+    print_tag(metatags, "keywords", Enum.join(value, ", "), config)
   end
 
   defp print_tag(_, key, value, _) do

--- a/lib/metatags/plug.ex
+++ b/lib/metatags/plug.ex
@@ -1,0 +1,35 @@
+defmodule Metatags.Plug do
+  @moduledoc """
+  Metatags.Plug is a plug that can be used in a Plug router
+  """
+
+  alias Plug.Conn
+
+  @behaviour Plug
+
+  @default_metatags %{"title" => nil}
+
+  @doc false
+  def init(options) do
+    default_tags = Keyword.get(options, :default_tags, [])
+    sitename = Keyword.get(options, :sitename, nil)
+    title_separator = Keyword.get(options, :title_separator, "-")
+
+    default_tags =
+      default_tags
+      |> Enum.reduce(@default_metatags, fn {key, value}, default_tags ->
+        Map.put(default_tags, to_string(key), value)
+      end)
+
+    %Metatags.Config{
+      sitename: sitename,
+      title_separator: title_separator,
+      metatags: default_tags
+    }
+  end
+
+  @doc false
+  def call(conn, defaults) do
+    Conn.put_private(conn, :metatags, defaults)
+  end
+end

--- a/test/metatags/config_test.exs
+++ b/test/metatags/config_test.exs
@@ -1,0 +1,12 @@
+defmodule Metatags.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Metatags.Config
+
+  describe "defstruct/1" do
+    test "defines a structure with defaults" do
+      assert %Config{sitename: nil, title_separator: "-", metatags: %{}} =
+               %Config{}
+    end
+  end
+end

--- a/test/metatags/html_test.exs
+++ b/test/metatags/html_test.exs
@@ -5,7 +5,7 @@ defmodule Metatags.HTMLTest do
   alias Metatags.HTML
   alias Phoenix.HTML.Safe
 
-  describe "from_conn" do
+  describe "from_conn/1" do
     test "returns the metatags as html" do
       conn = Metatags.put(build_conn(), "title", "my title")
 
@@ -47,27 +47,27 @@ defmodule Metatags.HTMLTest do
 
     test "adds the sitename as suffix to title when configured" do
       default_options = [sitename: "page"]
-      conn = Metatags.put(build_conn(), :title, "Welcome")
+      conn = Metatags.put(build_conn(default_options), :title, "Welcome")
 
-      assert safe_to_string(HTML.from_conn(conn, default_options)) =~
+      assert safe_to_string(HTML.from_conn(conn)) =~
                "<title>Welcome - page</title>"
     end
 
     test "prints the sitename when no title is set" do
-      conn = build_conn()
       default_options = [sitename: "page"]
+      conn = build_conn(default_options)
 
-      assert safe_to_string(HTML.from_conn(conn, default_options)) =~
+      assert safe_to_string(HTML.from_conn(conn)) =~
                "<title>page</title>"
     end
   end
 
   defp build_conn(default_metatags \\ []) do
-    defaults = Metatags.init(default_metatags)
+    defaults = Metatags.Plug.init(default_metatags)
 
     :get
     |> conn("/")
-    |> Metatags.call(defaults)
+    |> Metatags.Plug.call(defaults)
   end
 
   defp safe_to_string(safe_string) do

--- a/test/metatags/plug_test.exs
+++ b/test/metatags/plug_test.exs
@@ -1,0 +1,48 @@
+defmodule Metatags.PlugTest do
+  use ExUnit.Case, async: true
+
+  describe "init/1" do
+    test "returns the defaults when passed an empty map" do
+      assert %Metatags.Config{
+               metatags: %{"title" => nil},
+               title_separator: "-",
+               sitename: nil
+             } ==
+               Metatags.Plug.init([])
+    end
+
+    test "merges the passed config with the defaults" do
+      config = [sitename: "sitename", title_separator: "|"]
+
+      assert %{title_separator: "|", sitename: "sitename"} =
+               Metatags.Plug.init(config)
+    end
+
+    test "merges the passed `default_tags` with the predefined metatags" do
+      default_tags = [
+        title: "Welcome",
+        description: "a description"
+      ]
+
+      assert %{
+               metatags: %{
+                 "title" => "Welcome",
+                 "description" => "a description"
+               }
+             } = Metatags.Plug.init(default_tags: default_tags)
+    end
+  end
+
+  describe "call/2" do
+    test "puts the metatags config on the `Plug.Conn` struct" do
+      conn = %Plug.Conn{}
+
+      metatags = %Metatags.Config{
+        metatags: %{"title" => nil, "description" => "a description"}
+      }
+
+      assert %{private: %{metatags: ^metatags}} =
+               Metatags.Plug.call(conn, metatags)
+    end
+  end
+end

--- a/test/metatags_test.exs
+++ b/test/metatags_test.exs
@@ -2,41 +2,17 @@ defmodule MetatagsTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  describe "init" do
-    test "returns an empty keyword list" do
-      assert %{"title" => nil} == Metatags.init([])
-    end
-
-    test "returns the passed defaults as a map" do
-      assert %{"title" => "title"} == Metatags.init(defaults: [title: "title"])
-    end
-  end
-
-  describe "call" do
-    test "sets the passed defaults" do
-      conn = Metatags.call(conn(:get, "/"), %{"title" => nil})
-
-      assert %{"title" => nil} == conn.private.metatags
-    end
-
-    test "uses the passed defaults when present" do
-      conn = Metatags.call(conn(:get, "/"), %{"title" => "title"})
-
-      assert %{"title" => "title"} == conn.private.metatags
-    end
-  end
-
   describe "put" do
     test "puts the passed metatag data into the %Plug.Conn{}" do
       conn = Metatags.put(build_conn(), "title", "my title")
 
-      assert %{"title" => "my title"} == conn.private.metatags
+      assert %{"title" => "my title"} == conn.private.metatags.metatags
     end
 
     test "allows atoms as keys" do
       conn = Metatags.put(build_conn(), :title, "my title")
 
-      assert %{"title" => "my title"} == conn.private.metatags
+      assert %{"title" => "my title"} == conn.private.metatags.metatags
     end
   end
 
@@ -50,11 +26,11 @@ defmodule MetatagsTest do
   end
 
   defp build_conn(default_metatags \\ []) do
-    defaults = Metatags.init(default_metatags)
+    defaults = Metatags.Plug.init(default_metatags)
 
     :get
     |> conn("/")
-    |> Metatags.call(defaults)
+    |> Metatags.Plug.call(defaults)
   end
 
   defp safe_to_string(safe_string) do


### PR DESCRIPTION
Background:
To separate responsibilities into different modules we
can build a module structure that is easier to extend and
more clear to read/test.

Changes:
- Rework how modules are structured
- Extract plug related behaviours to `Metatags.Plug`
- Update `CHANGELOG.md`