### PR TITLE
Add support for common `<link>` elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ defmodule MyRouter do
   use Plug.Conn
 
   plug Metatags.Plug,
-     sitename: "My_app",
-     separator: "-",
-     default_tags: %{
-       "title" => "Welcome!",
-       "description" => "My_app is a great app",
-       "keywords" => ["My_app", "great", "elixir"]
-     }
+    sitename: "My_app",
+    separator: "-",
+    default_tags: %{
+      "title" => "Welcome!",
+      "description" => "My_app is a great app",
+      "keywords" => ["My_app", "great", "elixir"]
+    }
 ```
 
 ## Usage
@@ -46,6 +46,8 @@ conn
 |> Metatags.put("description", "My app is just a regular app")
 |> Metatags.put("og", %{"image" => "http://myimage.jpg"}) # You can have nested structures
 |> Metatags.put("og:image", "http://myimage.jpg") # or define them inline
+|> Metatags.put("canonical", "http://my-url.com")
+|> Metatags.put("alternate", "http://en.my-url.com", hreflang: "en-GB")
 ```
 
 And print them out inside your head tag
@@ -53,7 +55,7 @@ And print them out inside your head tag
 <!DOCTYPE>
 <html>
   <head>
-      <%= Metatags.print_tags(@conn) %>
+    <%= Metatags.print_tags(@conn) %>
   </head>
   <body>
     <h1>Welcome</h1>

--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -35,6 +35,11 @@ defmodule Metatags do
     Conn.put_private(conn, :metatags, metatags)
   end
 
+  @spec put(Conn.t(), String.t(), metatag_value, Keyword.t()) :: struct
+  def put(conn, key, value, extra_attributes) do
+    put(conn, key, {value, extra_attributes})
+  end
+
   @doc """
     Turns metadata information into HTML tags
   """

--- a/lib/metatags/html.ex
+++ b/lib/metatags/html.ex
@@ -3,8 +3,7 @@ defmodule Metatags.HTML do
   Transforms metatags to HTML
   """
 
-  alias Phoenix.HTML
-  alias Phoenix.HTML.Tag
+  alias Metatags.HTML.TagBuilder
 
   @doc """
   Turns a `%Plug.Conn{}` with metatags into HTML
@@ -14,7 +13,7 @@ defmodule Metatags.HTML do
     {metatags, config} = Map.pop(metatags, :metatags)
 
     Enum.reduce(metatags, [], fn {key, value}, acc ->
-      [print_tag(metatags, key, value, config) | acc]
+      [TagBuilder.print_tag(metatags, key, value, config) | acc]
     end)
   end
 
@@ -22,36 +21,5 @@ defmodule Metatags.HTML do
     raise ArgumentError,
       message:
         "No metatags was present in the passed struct. Did you forget to add it?"
-  end
-
-  defp print_tag(metatags, prefix, %{} = map, config) do
-    map
-    |> Enum.reduce([], fn {key, value}, acc ->
-      [print_tag(metatags, "#{prefix}:#{key}", value, config) | acc]
-    end)
-  end
-
-  defp print_tag(_, "title", nil, %{sitename: nil}), do: ""
-
-  defp print_tag(_, "title", value, %{sitename: sitename}) when is_nil(value) do
-    Tag.content_tag(:title, do: sitename)
-  end
-
-  defp print_tag(_, "title", value, %{
-         sitename: sitename,
-         title_separator: separator
-       }) do
-    suffix = if sitename, do: [separator, sitename], else: []
-
-    Tag.content_tag(:title, do: Enum.join([value] ++ suffix, " "))
-  end
-
-  defp print_tag(metatags, "keywords", value, config)
-       when is_list(value) do
-    print_tag(metatags, "keywords", Enum.join(value, ", "), config)
-  end
-
-  defp print_tag(_, key, value, _) do
-    Tag.tag(:meta, name: key, content: value)
   end
 end

--- a/lib/metatags/html/tag_builder.ex
+++ b/lib/metatags/html/tag_builder.ex
@@ -1,0 +1,38 @@
+defmodule Metatags.HTML.TagBuilder do
+  alias Phoenix.HTML.Tag
+
+  @type metatags_struct :: struct()
+
+  @spec print_tag(metatags_struct(), String.t(), any(), Metatags.Config.t()) ::
+          HTML.Safe.t()
+  def print_tag(metatags, prefix, %{} = map, config) do
+    map
+    |> Enum.reduce([], fn {key, value}, acc ->
+      [print_tag(metatags, "#{prefix}:#{key}", value, config) | acc]
+    end)
+  end
+
+  def print_tag(_, "title", nil, %{sitename: nil}), do: ""
+
+  def print_tag(_, "title", value, %{sitename: sitename}) when is_nil(value) do
+    Tag.content_tag(:title, do: sitename)
+  end
+
+  def print_tag(_, "title", value, %{
+        sitename: sitename,
+        title_separator: separator
+      }) do
+    suffix = if sitename, do: [separator, sitename], else: []
+
+    Tag.content_tag(:title, do: Enum.join([value] ++ suffix, " "))
+  end
+
+  def print_tag(metatags, "keywords", value, config)
+      when is_list(value) do
+    print_tag(metatags, "keywords", Enum.join(value, ", "), config)
+  end
+
+  def print_tag(_, key, value, _) do
+    Tag.tag(:meta, name: key, content: value)
+  end
+end

--- a/lib/metatags/html/tag_builder.ex
+++ b/lib/metatags/html/tag_builder.ex
@@ -1,4 +1,6 @@
 defmodule Metatags.HTML.TagBuilder do
+  @moduledoc false
+
   alias Phoenix.HTML.Tag
 
   @type metatags_struct :: struct()

--- a/lib/metatags/html/tag_builder.ex
+++ b/lib/metatags/html/tag_builder.ex
@@ -32,6 +32,38 @@ defmodule Metatags.HTML.TagBuilder do
     print_tag(metatags, "keywords", Enum.join(value, ", "), config)
   end
 
+  def print_tag(_, "next" = name, value, _) when is_binary(value) do
+    Tag.tag(:link, rel: name, href: value)
+  end
+
+  def print_tag(_, "canonical" = name, value, _) when is_binary(value) do
+    Tag.tag(:link, rel: name, href: value)
+  end
+
+  def print_tag(_, "alternate" = name, {value, extra_attributes}, _)
+      when is_list(extra_attributes) do
+    Tag.tag(:link, [rel: name, href: value] ++ extra_attributes)
+  end
+
+  def print_tag(_, "alternate" = name, value, _) when is_binary(value) do
+    Tag.tag(:link, rel: name, href: value)
+  end
+
+  def print_tag(_, "apple-touch-icon-precomposed" = name, value, _)
+      when is_binary(value) do
+    Tag.tag(:link, rel: name, href: value)
+  end
+
+  def print_tag(
+        _,
+        "apple-touch-icon-precomposed" = name,
+        {value, extra_attributes},
+        _
+      )
+      when is_list(extra_attributes) do
+    Tag.tag(:link, [rel: name, href: value] ++ extra_attributes)
+  end
+
   def print_tag(_, key, value, _) do
     Tag.tag(:meta, name: key, content: value)
   end

--- a/test/metatags/html/tag_builder_test.exs
+++ b/test/metatags/html/tag_builder_test.exs
@@ -1,0 +1,78 @@
+defmodule Metatags.HTML.TagBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias Metatags.Config
+  alias Metatags.HTML.TagBuilder
+  alias Phoenix.HTML.Safe
+
+  describe "print_tag/4" do
+    test "prints `title` with a `<title>` element" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "title", "my title", config)
+
+      assert safe_to_string(result) == "<title>my title</title>"
+    end
+
+    test "prints `next` with a `<link>` element" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "next", "https://example.com", config)
+
+      assert safe_to_string(result) == ~s(<link href="https://example.com" rel="next">)
+    end
+
+    test "prints `canonical` with a `<link>` element" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "canonical", "https://example.com", config)
+
+      assert safe_to_string(result) == ~s(<link href="https://example.com" rel="canonical">)
+    end
+
+    test "prints `alternate` with a `<link>` element" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "alternate", "https://example.com", config)
+
+      assert safe_to_string(result) == ~s(<link href="https://example.com" rel="alternate">)
+    end
+
+    test "prints `alternate` with a `<link>` element and extra attributes" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "alternate", {"https://example.com", hreflang: "sv-SE"}, config)
+
+      assert safe_to_string(result) == ~s(<link href="https://example.com" hreflang="sv-SE" rel="alternate">)
+    end
+
+    test "prints `apple-touch-icon-precomposed` with a `<link>` element and extra attributes" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "apple-touch-icon-precomposed", {"favicon.png", sizes: "144x144"} , config)
+
+      assert safe_to_string(result) == ~s(<link href="favicon.png" rel="apple-touch-icon-precomposed" sizes="144x144">)
+    end
+
+    test "prints `apple-touch-icon-precomposed` with a `<link>` element" do
+      metatags = %{}
+      config = %Config{}
+
+      result = TagBuilder.print_tag(metatags, "apple-touch-icon-precomposed", "favicon.png", config)
+
+      assert safe_to_string(result) == ~s(<link href="favicon.png" rel="apple-touch-icon-precomposed">)
+    end
+  end
+
+  defp safe_to_string(safe_string) do
+    safe_string
+    |> Safe.to_iodata()
+    |> IO.iodata_to_binary()
+  end
+end

--- a/test/metatags_test.exs
+++ b/test/metatags_test.exs
@@ -2,7 +2,7 @@ defmodule MetatagsTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  describe "put" do
+  describe "put/3" do
     test "puts the passed metatag data into the %Plug.Conn{}" do
       conn = Metatags.put(build_conn(), "title", "my title")
 
@@ -16,7 +16,19 @@ defmodule MetatagsTest do
     end
   end
 
-  describe "print_tags" do
+  describe "put/4" do
+    test "puts the value and extra attributes into the %Plug.Conn{}" do
+      conn =
+        Metatags.put(build_conn(), "canonical", "https://example.com/",
+          hreflang: "sv-SE"
+        )
+
+      assert %{"canonical" => {"https://example.com/", [hreflang: "sv-SE"]}} =
+               conn.private.metatags.metatags
+    end
+  end
+
+  describe "print_tags/1" do
     test "returns the defined tags" do
       conn = Metatags.put(build_conn(), "title", "hello world")
 


### PR DESCRIPTION
Background:
`<link>` elements can be used to define relationships
to other resources such as pages, icons and
alternate content.

Because it hasn't been needed or requested before,
metatags wouldn't know about how to print metadata
to html. This change will add support for a few new
special cases:

- `next`
- `canonical`
- `alternate`
- `apple-touch-icon-precomposed`

And also allows users to use `put/4` to add extra
attributes to those special cases. The code to
handle this will be revamped at some point to allow for
more strictness around following the HTML spec and throw
error messages (maybe even at compile time).

The newly added `put/4` can be used as such:

```elixir

conn
|> Metatags.put("title", "my title")
|> Metatags.put("alternate", "https://my-url.se", hreflang: "sv-SE")
|> Metatags.put("alternate", "https://my-url.com", hreflang: "en-US")
```

Fixes #4