### PR TITLE
Move `Conn`-related functions behind the `Transport` protocol

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -76,7 +76,6 @@
         #
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
-
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 90},
@@ -94,7 +93,6 @@
         {Credo.Check.Readability.VariableNames},
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SpaceAfterCommas},
-
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.CondStatements},
         {Credo.Check.Refactor.CyclomaticComplexity},
@@ -106,11 +104,10 @@
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.UnlessWithElse},
-
         {Credo.Check.Warning.BoolOperationOnSameValues},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.LazyLogging},
+        {Credo.Check.Warning.LazyLogging, false},
         {Credo.Check.Warning.OperationOnSameValues},
         {Credo.Check.Warning.OperationWithConstantResult},
         {Credo.Check.Warning.UnusedEnumOperation},
@@ -129,7 +126,7 @@
         {Credo.Check.Refactor.AppendSingleItem, false},
         {Credo.Check.Refactor.VariableRebinding, false},
         {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -5,38 +5,29 @@ defmodule Metatags do
   """
 
   alias Metatags.HTML
-  alias Plug.Conn
+  alias Metatags.Transport
 
   @type metatag_value ::
           String.t() | [String.t()] | {String.t(), Keyword.t()} | map() | nil
 
   @doc """
-  Puts a key and a value in the on a %Conn{} struct
+  Puts a key and a value in the on a the a struct adhering to the
+  `Metatags.Transport` protocol.
 
-  example:
+  ## Example:
 
-  ```
-  iex> conn = %Conn{}
-  iex> Metatags.put(conn, "title", "Welcome!")
-  %Conn{private: %{metadata: %{"title" => "Welcome!"}}}
-  ```
+    iex> conn = %Conn{}
+    iex> Metatags.put(conn, "title", "Welcome!")
+    %Conn{private: %{metadata: %{"title" => "Welcome!"}}}
+
   """
-  @spec put(Conn.t(), atom, metatag_value()) :: struct
-  def put(conn, key, value) when is_atom(key) do
-    put(conn, Atom.to_string(key), value)
+  @spec put(struct(), String.t() | atom(), metatag_value()) :: struct
+  def put(transport, key, value) do
+    Transport.put(transport, key, value)
   end
 
-  @spec put(Conn.t(), String.t(), metatag_value()) :: struct
-  def put(%Conn{private: %{metatags: metatags}} = conn, key, value) do
-    {_, metatags} =
-      Map.get_and_update(metatags, :metatags, fn metadata ->
-        {metadata, Map.put(metadata, key, value)}
-      end)
-
-    Conn.put_private(conn, :metatags, metatags)
-  end
-
-  @spec put(Conn.t(), String.t(), metatag_value, Keyword.t()) :: struct
+  @spec put(struct(), String.t() | atom(), metatag_value(), Keyword.t()) ::
+          struct()
   def put(conn, key, value, extra_attributes) do
     put(conn, key, {value, extra_attributes})
   end
@@ -44,8 +35,8 @@ defmodule Metatags do
   @doc """
   Turns metadata information into HTML tags
   """
-  @spec print_tags(Conn.t()) :: Phoenix.HTML.safe()
-  def print_tags(%Conn{} = conn) do
-    HTML.from_conn(conn)
+  @spec print_tags(struct()) :: Phoenix.HTML.safe()
+  def print_tags(transport) do
+    HTML.from_conn(transport)
   end
 end

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -9,21 +9,6 @@ defmodule Metatags.Config do
           metatags: %{}
         }
 
-  # def build(options) do
-  #   default_tags = Keyword.get(options, :default_tags, [])
-  #   sitename = Keyword.get(options, :sitename, nil)
-  #   title_separator = Keyword.get(options, :title_separator, "-")
-
-  #   default_tags =
-  #     Map.new(default_tags, fn {key, value} -> {to_string(key), value} end)
-
-  #   %Metatags.Config{
-  #     sitename: sitename,
-  #     title_separator: title_separator,
-  #     metatags: default_tags
-  #   }
-  # end
-
   @spec put_meta(t(), String.t() | atom(), any()) :: t()
   def put_meta(%__MODULE__{} = config, key, value) do
     put_in(config, [Access.key!(:metatags), to_string(key)], value)

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -8,4 +8,24 @@ defmodule Metatags.Config do
           title_separator: String.t(),
           metatags: %{}
         }
+
+  # def build(options) do
+  #   default_tags = Keyword.get(options, :default_tags, [])
+  #   sitename = Keyword.get(options, :sitename, nil)
+  #   title_separator = Keyword.get(options, :title_separator, "-")
+
+  #   default_tags =
+  #     Map.new(default_tags, fn {key, value} -> {to_string(key), value} end)
+
+  #   %Metatags.Config{
+  #     sitename: sitename,
+  #     title_separator: title_separator,
+  #     metatags: default_tags
+  #   }
+  # end
+
+  @spec put_meta(t(), String.t() | atom(), any()) :: t()
+  def put_meta(%__MODULE__{} = config, key, value) do
+    put_in(config, [Access.key!(:metatags), to_string(key)], value)
+  end
 end

--- a/lib/metatags/transport.ex
+++ b/lib/metatags/transport.ex
@@ -1,0 +1,9 @@
+defprotocol Metatags.Transport do
+  @moduledoc """
+  Functions for transporting metatada along with the request lifecycle,
+  whether it be a `Plug.Conn`, a `Phoenix.LiveView.Socket` or something else.
+  """
+
+  def put(transport, key, value)
+  def get_metatags(transport)
+end

--- a/lib/metatags/transport.ex
+++ b/lib/metatags/transport.ex
@@ -4,6 +4,11 @@ defprotocol Metatags.Transport do
   whether it be a `Plug.Conn`, a `Phoenix.LiveView.Socket` or something else.
   """
 
+  @type t :: struct()
+
+  @spec put(t(), String.t() | atom(), any()) :: t()
   def put(transport, key, value)
+
+  @spec get_metatags(t()) :: Metatags.Config.t()
   def get_metatags(transport)
 end

--- a/lib/metatags/transport/conn.ex
+++ b/lib/metatags/transport/conn.ex
@@ -1,0 +1,34 @@
+defimpl Metatags.Transport, for: Plug.Conn do
+  @moduledoc """
+  An implementation of `Metatags.Transport` for `Plug.Conn` where
+  metatags is stored inside the `private` key of the `Conn` struct.
+
+  To initialize the `Conn` transport you'd likely want to create a
+  custom plug which is called on every request.
+
+      defmodule MyApp.Plug.MetatagsPlug do
+
+        def init(conn, opts) do
+        end
+
+        def call(conn, opts) do
+        end
+      end
+    
+  """
+  alias Plug.Conn
+
+  def put(
+        %Conn{private: %{metatags: %Metatags.Config{} = metatags}} = conn,
+        key,
+        value
+      ) do
+    metatags = Metatags.Config.put_meta(metatags, key, value)
+
+    Conn.put_private(conn, :metatags, metatags)
+  end
+
+  def get_metatags(%Conn{private: %{metatags: %Metatags.Config{} = metatags}}) do
+    metatags
+  end
+end

--- a/test/metatags/transport/conn_test.exs
+++ b/test/metatags/transport/conn_test.exs
@@ -11,7 +11,11 @@ defmodule Metatags.Transport.ConnTest do
 
       conn = Transport.put(conn, "title", "my title")
 
-      assert %Plug.Conn{private: %{metatags: %Metatags.Config{metatags: %{"title" => "my title"}}}} = conn
+      assert %Plug.Conn{
+               private: %{
+                 metatags: %Metatags.Config{metatags: %{"title" => "my title"}}
+               }
+             } = conn
     end
   end
 
@@ -30,5 +34,4 @@ defmodule Metatags.Transport.ConnTest do
     |> conn("/")
     |> Metatags.Plug.call(defaults)
   end
-
 end

--- a/test/metatags/transport/conn_test.exs
+++ b/test/metatags/transport/conn_test.exs
@@ -1,9 +1,34 @@
 defmodule Metatags.Transport.ConnTest do
   use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Metatags.Config
+  alias Metatags.Transport
 
   describe "put/4" do
+    test "puts a value inside the `Conn` private scope" do
+      conn = build_conn()
+
+      conn = Transport.put(conn, "title", "my title")
+
+      assert %Plug.Conn{private: %{metatags: %Metatags.Config{metatags: %{"title" => "my title"}}}} = conn
+    end
   end
 
   describe "get_metatags/1" do
+    test "returns a `Metatags.Config`" do
+      conn = build_conn()
+
+      assert %Config{} = Transport.get_metatags(conn)
+    end
   end
+
+  defp build_conn(default_metatags \\ []) do
+    defaults = Metatags.Plug.init(default_metatags)
+
+    :get
+    |> conn("/")
+    |> Metatags.Plug.call(defaults)
+  end
+
 end

--- a/test/metatags/transport/conn_test.exs
+++ b/test/metatags/transport/conn_test.exs
@@ -1,0 +1,9 @@
+defmodule Metatags.Transport.ConnTest do
+  use ExUnit.Case, async: true
+
+  describe "put/4" do
+  end
+
+  describe "get_metatags/1" do
+  end
+end


### PR DESCRIPTION
Background:
In order to move forward to support phoenix live view, this change will create a `Transport` protocol which will act as an adapter and make it possible to make metatags more flexible by allowing different structs acting as a transport layer of metatags throughout a request life cycle.

Part of #156 