### PR TITLE
Remove `Conn` dependency from `HTML`

### DIFF
--- a/lib/metatags.ex
+++ b/lib/metatags.ex
@@ -4,6 +4,7 @@ defmodule Metatags do
   metatags.
   """
 
+  alias Metatags.Config
   alias Metatags.HTML
   alias Metatags.Transport
 
@@ -37,6 +38,19 @@ defmodule Metatags do
   """
   @spec print_tags(struct()) :: Phoenix.HTML.safe()
   def print_tags(transport) do
-    HTML.from_conn(transport)
+    transport
+    |> Transport.get_metatags()
+    |> add_missing_canonical(transport)
+    |> HTML.from_metatags()
+  end
+
+  defp add_missing_canonical(metatags, transport) do
+    if Map.has_key?(metatags.metatags, "canonical") do
+      metatags
+    else
+      canonical_url = Transport.canonical_url(transport)
+
+      Config.put_meta(metatags, "canonical", canonical_url)
+    end
   end
 end

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -9,20 +9,22 @@ defmodule Metatags.Config do
           metatags: %{}
         }
 
-  # def build(options) do
-  #   default_tags = Keyword.get(options, :default_tags, [])
-  #   sitename = Keyword.get(options, :sitename, nil)
-  #   title_separator = Keyword.get(options, :title_separator, "-")
+  def build(options) do
+    default_tags = Keyword.get(options, :default_tags, [])
+    sitename = Keyword.get(options, :sitename, nil)
+    title_separator = Keyword.get(options, :title_separator, "-")
 
-  #   default_tags =
-  #     Map.new(default_tags, fn {key, value} -> {to_string(key), value} end)
+    default_tags =
+      [{"title", nil}]
+      |> Keyword.merge(default_tags)
+      |> Map.new(fn {key, value} -> {to_string(key), value} end)
 
-  #   %Metatags.Config{
-  #     sitename: sitename,
-  #     title_separator: title_separator,
-  #     metatags: default_tags
-  #   }
-  # end
+    %Metatags.Config{
+      sitename: sitename,
+      title_separator: title_separator,
+      metatags: default_tags
+    }
+  end
 
   @spec put_meta(t(), String.t() | atom(), any()) :: t()
   def put_meta(%__MODULE__{} = config, key, value) do

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -9,17 +9,18 @@ defmodule Metatags.Config do
           metatags: %{}
         }
 
-  def build(options) do
+  @spec build(Keyword.t()) :: __MODULE__.t()
+  def build(options) when is_list(options) do
     default_tags = Keyword.get(options, :default_tags, [])
     sitename = Keyword.get(options, :sitename, nil)
     title_separator = Keyword.get(options, :title_separator, "-")
 
     default_tags =
-      [{"title", nil}]
-      |> Keyword.merge(default_tags)
-      |> Map.new(fn {key, value} -> {to_string(key), value} end)
+      Map.new([{"title", nil} | default_tags], fn {key, value} ->
+        {to_string(key), value}
+      end)
 
-    %Metatags.Config{
+    %__MODULE__{
       sitename: sitename,
       title_separator: title_separator,
       metatags: default_tags

--- a/lib/metatags/config.ex
+++ b/lib/metatags/config.ex
@@ -9,6 +9,21 @@ defmodule Metatags.Config do
           metatags: %{}
         }
 
+  # def build(options) do
+  #   default_tags = Keyword.get(options, :default_tags, [])
+  #   sitename = Keyword.get(options, :sitename, nil)
+  #   title_separator = Keyword.get(options, :title_separator, "-")
+
+  #   default_tags =
+  #     Map.new(default_tags, fn {key, value} -> {to_string(key), value} end)
+
+  #   %Metatags.Config{
+  #     sitename: sitename,
+  #     title_separator: title_separator,
+  #     metatags: default_tags
+  #   }
+  # end
+
   @spec put_meta(t(), String.t() | atom(), any()) :: t()
   def put_meta(%__MODULE__{} = config, key, value) do
     put_in(config, [Access.key!(:metatags), to_string(key)], value)

--- a/lib/metatags/html.ex
+++ b/lib/metatags/html.ex
@@ -3,8 +3,8 @@ defmodule Metatags.HTML do
   Transforms metatags to HTML
   """
 
-  alias Metatags.HTML.TagBuilder
   alias Metatags.Config
+  alias Metatags.HTML.TagBuilder
 
   @doc """
   Turns a `%Plug.Conn{}` with metatags into HTML

--- a/lib/metatags/html.ex
+++ b/lib/metatags/html.ex
@@ -4,37 +4,17 @@ defmodule Metatags.HTML do
   """
 
   alias Metatags.HTML.TagBuilder
-  alias Plug.Conn
+  alias Metatags.Config
 
   @doc """
   Turns a `%Plug.Conn{}` with metatags into HTML
   """
-  @spec from_conn(Conn.t()) :: Phoenix.HTML.safe()
-  def from_conn(%Conn{private: %{metatags: metatags}} = conn) do
-    {metatags, config} = Map.pop(metatags, :metatags)
+  @spec from_metatags(Config.t()) :: Phoenix.HTML.safe()
+  def from_metatags(%Config{} = config) do
+    {metatags, config} = Map.pop(config, :metatags)
 
-    metatags
-    |> set_missing_canonical(fn -> request_url(conn) end)
-    |> Enum.reduce([], fn {key, value}, acc ->
+    Enum.reduce(metatags, [], fn {key, value}, acc ->
       [TagBuilder.print_tag(metatags, key, value, config) | acc]
     end)
-  end
-
-  def from_conn(_) do
-    raise ArgumentError,
-      message:
-        "No metatags was present in the passed struct. Did you forget to add it?"
-  end
-
-  defp set_missing_canonical(%{"canonical" => _} = metatags, _func) do
-    metatags
-  end
-
-  defp set_missing_canonical(metatags, func) do
-    Map.put(metatags, "canonical", func.())
-  end
-
-  defp request_url(conn) do
-    Conn.request_url(%Conn{conn | query_string: ""})
   end
 end

--- a/lib/metatags/transport.ex
+++ b/lib/metatags/transport.ex
@@ -11,4 +11,5 @@ defprotocol Metatags.Transport do
 
   @spec get_metatags(t()) :: Metatags.Config.t()
   def get_metatags(transport)
+  def canonical_url(transport)
 end

--- a/lib/metatags/transport/conn.ex
+++ b/lib/metatags/transport/conn.ex
@@ -31,4 +31,8 @@ defimpl Metatags.Transport, for: Plug.Conn do
   def get_metatags(%Conn{private: %{metatags: %Metatags.Config{} = metatags}}) do
     metatags
   end
+
+  def canonical_url(%Conn{} = conn) do
+    Conn.request_url(%Conn{conn | query_string: ""})
+  end
 end

--- a/test/metatags/html_test.exs
+++ b/test/metatags/html_test.exs
@@ -2,104 +2,65 @@ defmodule Metatags.HTMLTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
+  alias Metatags.Config
   alias Metatags.HTML
   alias Phoenix.HTML.Safe
 
-  describe "from_conn/1" do
+  describe "from_metatags/1" do
     test "returns the metatags as html" do
-      conn = Metatags.put(build_conn(), "title", "my title")
+      metatags = Config.put_meta(build_config(), "title", "my title")
 
-      assert safe_to_string(HTML.from_conn(conn)) =~ "<title>my title</title>"
+      assert safe_to_string(HTML.from_metatags(metatags)) =~
+               "<title>my title</title>"
     end
 
     test "returns a Phoenix.HTML.Safe" do
-      conn = Metatags.put(build_conn(), "title", "my title")
+      conn = Config.put_meta(build_config(), "title", "my title")
 
-      assert [{:safe, _}, {:safe, _}] = HTML.from_conn(conn)
-    end
-
-    test "raises an error when not passed a %Plug.Conn{}" do
-      conn = %{}
-
-      assert_raise ArgumentError, fn -> HTML.from_conn(conn) end
+      assert [{:safe, _}] = HTML.from_metatags(conn)
     end
 
     test "prints a list of keywords as a comma separated string" do
-      conn = Metatags.put(build_conn(), :keywords, ["metatags", "awesome"])
+      conn = Config.put_meta(build_config(), :keywords, ["metatags", "awesome"])
 
-      assert safe_to_string(HTML.from_conn(conn)) =~
+      assert safe_to_string(HTML.from_metatags(conn)) =~
                ~s(<meta content="metatags, awesome" name="keywords">)
     end
 
     test "prints nested maps as keys with prefixes" do
-      conn = Metatags.put(build_conn(), :prefix, %{key: "value"})
+      conn = Config.put_meta(build_config(), :prefix, %{key: "value"})
 
-      assert safe_to_string(HTML.from_conn(conn)) =~
+      assert safe_to_string(HTML.from_metatags(conn)) =~
                ~s(<meta content="value" name="prefix:key">)
     end
 
     test "prints a key and value with name and content attributes" do
-      conn = Metatags.put(build_conn(), :anything, "value")
+      conn = Config.put_meta(build_config(), :anything, "value")
 
-      assert safe_to_string(HTML.from_conn(conn)) =~
+      assert safe_to_string(HTML.from_metatags(conn)) =~
                ~s(<meta content="value" name="anything">)
     end
 
     test "adds the sitename as suffix to title when configured" do
       default_options = [sitename: "page"]
-      conn = Metatags.put(build_conn(default_options), :title, "Welcome")
+      conn = Config.put_meta(build_config(default_options), :title, "Welcome")
 
-      assert safe_to_string(HTML.from_conn(conn)) =~
+      assert safe_to_string(HTML.from_metatags(conn)) =~
                "<title>Welcome - page</title>"
     end
 
     test "prints the sitename when no title is set" do
       default_options = [sitename: "page"]
-      conn = build_conn(default_options)
+      metatags = build_config(default_options)
 
-      assert safe_to_string(HTML.from_conn(conn)) =~
+      assert safe_to_string(HTML.from_metatags(metatags)) =~
                "<title>page</title>"
     end
 
-    test "sets a missing canonical metatag to current url" do
-      default_options = []
-      conn = build_conn(default_options)
-
-      assert safe_to_string(HTML.from_conn(conn)) =~
-               ~s(<link href="http://www.example.com/" rel="canonical">)
-    end
-
-    test "does not override a set canonical metatag" do
-      default_options = []
-
-      conn =
-        default_options
-        |> build_conn()
-        |> Metatags.put("canonical", "https://example.com/canonical/path")
-
-      assert safe_to_string(HTML.from_conn(conn)) =~
-               ~s(<link href="https://example.com/canonical/path" rel="canonical">)
-    end
-
-    test "ignores query params when setting an automated canonical url" do
-      default_metatags = []
-
-      conn =
-        :get
-        |> conn("/path/?query=params")
-        |> Metatags.Plug.call(Metatags.Plug.init(default_metatags))
-
-      assert safe_to_string(HTML.from_conn(conn)) =~
-               ~s(<link href="http://www.example.com/path/" rel="canonical">)
-    end
   end
 
-  defp build_conn(default_metatags \\ []) do
-    defaults = Metatags.Plug.init(default_metatags)
-
-    :get
-    |> conn("/")
-    |> Metatags.Plug.call(defaults)
+  defp build_config(defaults \\ []) do
+    Config.build(defaults)
   end
 
   defp safe_to_string(safe_string) do

--- a/test/metatags/html_test.exs
+++ b/test/metatags/html_test.exs
@@ -56,7 +56,6 @@ defmodule Metatags.HTMLTest do
       assert safe_to_string(HTML.from_metatags(metatags)) =~
                "<title>page</title>"
     end
-
   end
 
   defp build_config(defaults \\ []) do

--- a/test/metatags_test.exs
+++ b/test/metatags_test.exs
@@ -35,6 +35,39 @@ defmodule MetatagsTest do
       assert safe_to_string(Metatags.print_tags(conn)) =~
                "<title>hello world</title>"
     end
+
+    
+    test "sets a missing canonical metatag to current url" do
+      default_options = []
+      conn = build_conn(default_options)
+
+      assert safe_to_string(Metatags.print_tags(conn)) =~
+               ~s(<link href="http://www.example.com/" rel="canonical">)
+    end
+
+    test "does not override a set canonical metatag" do
+      default_options = []
+
+      conn =
+        default_options
+        |> build_conn()
+        |> Metatags.put("canonical", "https://example.com/canonical/path")
+
+      assert safe_to_string(Metatags.print_tags(conn)) =~
+               ~s(<link href="https://example.com/canonical/path" rel="canonical">)
+    end
+
+    test "ignores query params when setting an automated canonical url" do
+      default_metatags = []
+
+      conn =
+        :get
+        |> conn("/path/?query=params")
+        |> Metatags.Plug.call(Metatags.Plug.init(default_metatags))
+
+      assert safe_to_string(Metatags.print_tags(conn)) =~
+               ~s(<link href="http://www.example.com/path/" rel="canonical">)
+    end
   end
 
   defp build_conn(default_metatags \\ []) do

--- a/test/metatags_test.exs
+++ b/test/metatags_test.exs
@@ -36,7 +36,6 @@ defmodule MetatagsTest do
                "<title>hello world</title>"
     end
 
-    
     test "sets a missing canonical metatag to current url" do
       default_options = []
       conn = build_conn(default_options)


### PR DESCRIPTION
Background: To create a future that gives more flexibility and the ability
to use any data structure to manage metatags during the request lifecycle,
this change will change `HTML` to no longer take a `Conn`, but rather
receive a `Metatags.Config` struct and build the tags from that.

Part of #156 