### PR TITLE
Update Elixir to 1.20.1 and Erlang/OTP to 29.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: '27.1'
-  ELIXIR_VERSION: '1.17.3'
+  OTP_VERSION: '29.0.2'
+  ELIXIR_VERSION: '1.20.1'
 
 jobs:
   deps:


### PR DESCRIPTION
Bumps the CI toolchain to the latest stable releases: Erlang/OTP `27.1` → `29.0.2` and Elixir `1.17.3` → `1.20.1`. These versions are compatible since Elixir 1.20 supports OTP 27–29. The versions are only pinned in the CI workflow env, so no other files needed changing.